### PR TITLE
loaderUtils.parseQuery is deprecated

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = function(source) {
   this.cacheable && this.cacheable();
   var value = typeof source === "string" ? HJSON.parse(source) : source;
   this.value = [value];
-  var query = loaderUtils.parseQuery(this.query);
+  var query = loaderUtils.getOptions(this) || {};
   stringified = JSON.stringify(value, undefined, "\t");
   return query.str ? stringified : 'module.exports = ' + stringified + ';';
 }

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "url": "https://github.com/garlictech/hjson-loader.git"
   },
   "peerDependencies": {
-    "hjson": "^1.7.4"
+    "hjson": "^2.4.2"
   },
   "dependencies": {
-    "loader-utils": "^0.2.12"
+    "loader-utils": "^1.1.0"
   }
 }


### PR DESCRIPTION
- loaderUtils.parseQuery is deprecated, it is replaced with loaderUtils.getOptions.
- hjson and loaderUtils is updated.